### PR TITLE
Adds the ability to use idSync fields in the UI

### DIFF
--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -27,13 +27,12 @@ const MainContainer = () => {
 
     return (
         <div style={{display:"flex", justifyContent:"space-evenly"}}>
-            {/* <LeftOverview />
+            <LeftOverview />
             <Overview 
                 traits={traits} 
                 space={space} 
                 audience={audience}
-            /> */}
-            <p>{JSON.stringify(Object.keys(state))}</p>
+            />
         </div>
     )
 }

--- a/src/state-management/actions.js
+++ b/src/state-management/actions.js
@@ -4,3 +4,4 @@ export const setCurrentSpaceAction = (space) => ({ type: 'SET_CURRENT_SPACE', pa
 export const setCurrentAudienceAction = (audience) => ({ type: 'SET_CURRENT_AUDIENCE', payload: audience});
 export const setCurrentTraitsAction = (traits) => ({ type: 'SET_CURRENT_TRAITS', payload: traits});
 export const setUpdatedTraitsAction = (updatedTraits) => ({ type: 'SET_UPDATED_TRAITS', payload: updatedTraits});
+export const setIdSyncIds = (ids) => ({ type: 'SET_ID_SYNC_IDS', payload: ids});

--- a/src/state-management/reducer.js
+++ b/src/state-management/reducer.js
@@ -17,7 +17,9 @@ export const reducer = (state, action) => {
             return { ...state, currentTraits: action.payload };
         // updated traits object from updateAudienceDestination.data.updateAudienceDestination.profileSyncConfig.traitMapping.mapping
         case 'SET_UPDATED_TRAITS':
-            return { ...state, updatedTraits: action.payload };       
+            return { ...state, updatedTraits: action.payload };      
+        case 'SET_ID_SYNC_IDS': 
+            return { ...state, currentIds: action.payload }; 
         default:
             return state;
     }

--- a/src/utilities/handlerequest.js
+++ b/src/utilities/handlerequest.js
@@ -5,7 +5,8 @@ import {
     setCurrentSpaceAction, 
     setCurrentAudienceAction,
     setCurrentTraitsAction,
-    setUpdatedTraitsAction
+    setUpdatedTraitsAction,
+    setIdSyncIds
 } from '../state-management/actions';
 
 export const handleRequest = async (requestURL, requestBody, getState, dispatch) => {
@@ -28,6 +29,7 @@ export const handleRequest = async (requestURL, requestBody, getState, dispatch)
         audience: () => !state.currentAudience ? setCurrentAudienceAction(handled.audience) : null,
         traits: () => setCurrentTraitsAction(handled.traits),
         updatedTraits: () => setUpdatedTraitsAction(handled.updatedTraits),
+        ids: () => setIdSyncIds(handled.ids)
     };
 
     const actions = Object.entries(actionMap)


### PR DESCRIPTION
You can access those fields at `state.currentIds`. 

Here is how the data is formatted: 

<img width="616" alt="Screenshot 2024-08-30 at 3 18 10 PM" src="https://github.com/user-attachments/assets/4a5cfc13-a92c-44bd-a7ae-9125f7ffe75b">

<img width="1491" alt="Screenshot 2024-08-30 at 3 17 42 PM" src="https://github.com/user-attachments/assets/00042ed3-691f-4b96-94c3-0d9ed9c65ea4">
