### PR TITLE
delete context.traits.email from Identify

### DIFF
--- a/src/containers/MainContainer.css
+++ b/src/containers/MainContainer.css
@@ -1,0 +1,13 @@
+#slide {
+    /* background-color: var(--accent-900);
+    z-index: 10;
+    position: absolute; */
+    cursor: ew-resize;
+    width: 20px;
+    /* height: 100%; */
+    min-height: 20px;
+    justify-self: center;
+    align-self: start;
+    margin-top: 20em;
+    background-color: red;
+}

--- a/src/containers/MainContainer.jsx
+++ b/src/containers/MainContainer.jsx
@@ -33,7 +33,7 @@ const MainContainer = () => {
         <div style={{display:"flex", justifyContent:"space-evenly"}}>
             <LeftOverview />
             <Overview 
-                traits={traits} 
+                idTraits={traits} 
                 space={space} 
                 audience={audience}
                 ids={ids}

--- a/src/containers/RightBox/Overview/Overview.jsx
+++ b/src/containers/RightBox/Overview/Overview.jsx
@@ -4,7 +4,7 @@ import { SamplePayload } from "../SamplePayload/SamplePayload"
 import { useState } from "react";
 import './Overview.css';
 
-const Overview = ({traits, space, audience, ids}) => {
+const Overview = ({idTraits, space, audience, ids}) => {
     const [selectedPayloadType, setSelectedPayloadType] = useState('track');
 
 
@@ -17,11 +17,11 @@ const Overview = ({traits, space, audience, ids}) => {
             <ButtonBox 
                 handleButtonClick={handleButtonClick}
             />
-            {!traits ? 
+            {!idTraits ? 
             
                 <InfoBox /> : 
                 <SamplePayload 
-                selectedPayloadType={selectedPayloadType} traits={traits} 
+                selectedPayloadType={selectedPayloadType} idTraits={idTraits} 
                 audience={audience}
                 space={space}
                 ids={ids}

--- a/src/containers/RightBox/SamplePayload/Payload.jsx
+++ b/src/containers/RightBox/SamplePayload/Payload.jsx
@@ -19,7 +19,8 @@ const basePayload = {
   }
 };
 
-const Payload = ({ traits, selectedPayloadType, space, audience, ids}) => {
+const Payload = ({ idTraits, selectedPayloadType, space, audience, ids}) => {
+  console.log('TRAITS, ', idTraits)
   let payload = {
     ...basePayload,
     // ...additionalData, // Allows overriding the type and adding properties/traits from additionalData - REMOVED as this was added for initial stage testing
@@ -69,30 +70,31 @@ const Payload = ({ traits, selectedPayloadType, space, audience, ids}) => {
       properties: {
         ...payload.properties, // Use the updated payload properties
         // ...additionalData.properties, // Merge and override with properties from additionalData - REMOVED as this was added for initial stage testing
-        ...traits // Add in specified traits from Trait Activation
+        ...idTraits // Add in specified traits from Trait Activation
       }
     };
     appendIds(payload.properties, payload.context.traits.email); 
 
     // Handle email trait if not coming from ids
-    if (traits && traits.email && !ids.email) {
+    if (idTraits && idTraits.email && !ids.email) {
       if (!payload.context.traits) {
         payload.context.traits = {};
       }
-      payload.context.traits.email = traits.email;
-      delete traits.email;
+      payload.context.traits.email = idTraits.email;
+      // delete traits.email; // (THIS IS DELETING FROM PROPS! NEED TO RENAME THE PROP)
     }
 
-  } else {
+  } else  if (selectedPayloadType === 'identify') {
     delete payload.properties;
- 
+    delete payload.context.traits.email;
+
     payload = {
       ...payload,
       type: selectedPayloadType,
       traits: {
         ...payload.traits, // Use the updated payload traits
         // ...additionalData.traits, // Merge and override with traits from additionalData - REMOVED as this was added for initial stage testing
-        ...traits // Add in specified traits from Trait Activation
+        ...idTraits // Add in specified traits from Trait Activation
       }
     };
     appendIds(payload.traits);

--- a/src/containers/RightBox/SamplePayload/SamplePayload.jsx
+++ b/src/containers/RightBox/SamplePayload/SamplePayload.jsx
@@ -3,7 +3,7 @@ import IconCopy16 from './Icon'
 import Payload from './Payload'
 import CopyPayload from './CopyPayload'
 
-export const SamplePayload = ({selectedPayloadType, traits, space, audience, ids}) => {
+export const SamplePayload = ({selectedPayloadType, idTraits, space, audience, ids}) => {
     return(
         <>
             <div id='label-box'>
@@ -15,7 +15,7 @@ export const SamplePayload = ({selectedPayloadType, traits, space, audience, ids
                     <code className='payload-text'>
                     <Payload 
                         selectedPayloadType={selectedPayloadType} 
-                        traits={traits}
+                        idTraits={idTraits}
                         space={space}
                         audience={audience}
                         ids={ids}


### PR DESCRIPTION
-removes `context.traits.email` from Identify sample payload
-renames `traits` from state to `idTraits` to resolve a naming conflict in Payload.jsx